### PR TITLE
Add nginx caching proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+- Run application: `docker compose up` or `docker compose up -d` (daemon mode)
+- Rebuild container: `docker compose up --build 'hayhooks'`
+- Complete reset: `docker compose down -v --remove-orphans && docker compose up --build`
+
+## Test Commands
+- Run all tests: `pytest tests/`
+- Run specific test: `pytest tests/components/test_content_extraction.py`
+
+## Development Environment
+- Python: 3.12 required
+- Package management: `uv venv && source .venv/bin/activate && uv sync`
+- Node.js tools: `npm run build`, `npm run start`, `npm run dev`
+
+## Code Style
+- Type annotations for all function signatures
+- Descriptive function and variable names
+- Follow existing import organization patterns
+- Clear error handling with appropriate logging
+- Document public APIs with docstrings
+- Validate input parameters, especially URLs and file paths
+- Organize code in logical directories (components/, pipelines/, resources/)
+- Maintain strict type checking where applicable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  # Nginx reverse proxy with HTTPS termination and caching
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - nginx_cache:/var/cache/nginx
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   # LiteLLM can be enabled in Open WebUI if you want direct access to models
   litellm:
@@ -26,29 +42,33 @@ services:
       # Could probably use gemini-2.0-flash-lite here 
       - SEARCH_MODEL=gemini-2.0-flash
       - EXTRACT_MODEL=gemini-2.0-flash
-      - HAYHOOKS_PIPELINES_DIR=/pipelines
-      - HAYHOOKS_DISABLE_SSL=true
-      - HAYHOOKS_HOST=0.0.0.0
-      - HAYHOOKS_PORT=1416
-      - LOG_LEVEL=INFO
-      - HAYSTACK_LOG_LEVEL=INFO
-      - HAYHOOKS_SHOW_TRACEBACKS=true
       # Needed for search pipeline
       - TAVILY_API_KEY=$TAVILY_API_KEY
       - OPENWEBUI_BASE_URL=http://open-webui:8080
       - LETTA_BASE_URL=http://letta:8283      
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:1416/status"]
-      interval: 10s
-      timeout: 5s
-      retries: 18
-      start_period: 5s
+      # App Settings
+      - LOG_LEVEL=INFO
+      #This isn't working :-/
+      #- HTTP_PROXY=http://nginx:8888
+      #- HTTPS_PROXY=http://nginx:8888
+      - NO_PROXY=letta,open-webui,litellm
+      # Hayhooks settings
+      - HAYHOOKS_PIPELINES_DIR=/pipelines
+      - HAYHOOKS_DISABLE_SSL=true      
+      - HAYHOOKS_HOST=0.0.0.0
+      - HAYHOOKS_PORT=1416  
+      - HAYHOOKS_SHOW_TRACEBACKS=true
+      # Haystack settings (we get calls to posthog if telemetry is enabled)
+      - HAYSTACK_LOG_LEVEL=INFO
+      - HAYSTACK_TELEMETRY_ENABLED=false      
+    depends_on:
+      - nginx   
 
   # Letta is an agent building framework with built-in memory/vectordb support.
   # https://docs.letta.com/quickstart/docker
   letta:
-    image: letta/letta:0.6.48
-    container_name: letta
+    image: letta:latest
+    container_name: groundedllm_letta
     ports:
       - 8283:8283
     volumes:
@@ -65,11 +85,11 @@ services:
       timeout: 5s
       retries: 18
       start_period: 1s
-    #depends_on:
-      #wikipedia-mcp-server:
-      #  condition: service_healthy
-      #aws-documentation-mcp-server:
-      #  condition: service_healthy
+    depends_on:
+      wikipedia-mcp-server:
+        condition: service_started
+      letta-mcp-server:
+        condition: service_started
 
   # Open WebUI is the front-end UI to Letta
   open-webui:
@@ -78,7 +98,7 @@ services:
     volumes:
      - open-webui:/app/backend/data
     ports:
-      - ${OPEN_WEBUI_PORT-3000}:8080
+      - "3000:8080"
     environment:
       # https://docs.openwebui.com/getting-started/env-configuration/
       - GLOBAL_LOG_LEVEL=WARNING
@@ -138,31 +158,37 @@ services:
       - CHAT_MODEL=anthropic/claude-3-7-sonnet-20250219
       - EMBEDDING_MODEL=google_ai/text-embedding-004
 
-  aws-documentation-mcp-server:
-    build: mcp/aws-documentation-mcp-server/
-    container_name: aws-documentation-mcp-server
-    ports:
-      - 9712:9712
-    environment:
-      - LOG_LEVEL=ERROR
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:9712/sse"]
-      interval: 10s
-      timeout: 5s
-      retries: 18
-      start_period: 5s
+  # aws-documentation-mcp-server:
+  #   build: mcp/aws-documentation-mcp-server/
+  #   container_name: aws-documentation-mcp-server
+  #   ports:
+  #     - 9712:9712
+  #   environment:
+  #     - LOG_LEVEL=ERROR
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://127.0.0.1:9712/sse"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 18
+  #     start_period: 5s
 
   wikipedia-mcp-server:
     build: mcp/wikipedia-mcp-server/
     container_name: wikipedia-mcp-server
     ports:
       - 9713:9713
+    #environment:
+      # - HTTP_PROXY=http://nginx:80
+      # - HTTPS_PROXY=http://nginx:80
+      # - NO_PROXY=hayhooks,letta,open-webui,nginx,litellm
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:9713/sse"]
       interval: 10s
       timeout: 5s
       retries: 18
       start_period: 5s
+    depends_on:
+      - nginx
 
   letta-mcp-server:
     build: mcp/letta-mcp-server/
@@ -181,3 +207,4 @@ services:
 
 volumes:
   open-webui:
+  nginx_cache:

--- a/letta_mcp_config.json
+++ b/letta_mcp_config.json
@@ -5,11 +5,6 @@
       "disabled": false,
       "autoApprove": []
     },
-    "aws-documentation-mcp-server": {
-      "url": "http://aws-documentation-mcp-server:9712/sse",
-      "disabled": false,
-      "autoApprove": []
-    },
     "wikipedia-mcp-server": {
       "url": "http://wikipedia-mcp-server:9713/sse",
       "disabled": false,

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,40 @@
+FROM nginx:latest
+
+# Install necessary tools
+RUN apt-get update && apt-get install -y openssl curl
+
+# Create directories
+RUN mkdir -p /var/cache/nginx/proxy_cache
+RUN mkdir -p /var/cache/nginx/api_cache
+RUN mkdir -p /var/cache/nginx/external_cache
+RUN mkdir -p /etc/nginx/certs
+RUN mkdir -p /usr/share/nginx/html
+
+# Copy index.html
+COPY index.html /usr/share/nginx/html/index.html
+
+# Create health check file
+RUN echo "healthy" > /usr/share/nginx/html/health
+
+# Copy configuration files
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY conf.d/ /etc/nginx/conf.d/
+
+# Generate self-signed certificate for localhost
+RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /etc/nginx/certs/nginx.key \
+    -out /etc/nginx/certs/nginx.crt \
+    -subj "/C=US/ST=State/L=City/O=GroundedLLM/CN=localhost"
+
+# Generate DH parameters for improved security
+RUN openssl dhparam -out /etc/nginx/certs/dhparam.pem 2048
+
+# Set proper permissions for certificates
+RUN chmod 644 /etc/nginx/certs/nginx.crt \
+    && chmod 600 /etc/nginx/certs/nginx.key \
+    && chmod 644 /etc/nginx/certs/dhparam.pem
+
+# Expose ports
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/conf.d/caching.conf
+++ b/nginx/conf.d/caching.conf
@@ -1,0 +1,56 @@
+# Additional caching rules for GroundedLLM
+
+# Cache control headers
+proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
+
+# Don't cache requests with authentication
+map $http_authorization $skip_cache {
+    default 1;
+    "" 0;
+}
+
+# Don't cache streaming requests
+map $http_accept $skip_streaming_cache {
+    "~*text/event-stream" 1;
+    default 0;
+}
+
+# Forward proxy setup for Hayhooks external content
+server {
+    listen 8888;
+    
+    # Access log with cache status
+    access_log /var/log/nginx/proxy_access.log main;
+    
+    # Resolver for DNS lookups
+    resolver 8.8.8.8 ipv6=off;
+    
+    # Proxy settings
+    location / {
+        proxy_pass $scheme://$host$request_uri;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Caching settings for external content
+        proxy_cache external_cache;
+        proxy_cache_valid 200 302 24h;
+        proxy_cache_valid 404 30m;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock on;
+        add_header X-Cache-Status $upstream_cache_status;
+        
+        # Skip cache for certain conditions
+        proxy_cache_bypass $skip_cache $skip_streaming_cache;
+        
+        # Set appropriate timeouts
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
+        # Enable HTTP/2
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}

--- a/nginx/index.html
+++ b/nginx/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Nginx Placeholder</title>
+</head>
+<body>
+<h1>Nginx is running</h1>
+<p>This is the default placeholder page.</p>
+</body>
+</html>

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,78 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    
+    # Logging settings
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time" '
+                    'cache_status=$upstream_cache_status';
+    
+    # Define a map to set $loggable to 0 for health check requests
+    map $request_uri $loggable {
+        ~/health    0;
+        default     1;
+    }
+    
+    access_log /var/log/nginx/access.log main if=$loggable;
+    
+    # Basic settings
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
+    
+    # Cache configuration
+    proxy_cache_path /var/cache/nginx/proxy_cache 
+                    levels=1:2 
+                    keys_zone=static_cache:10m 
+                    max_size=1g 
+                    inactive=60m;
+    proxy_cache_path /var/cache/nginx/api_cache 
+                    levels=1:2 
+                    keys_zone=api_cache:10m 
+                    max_size=500m 
+                    inactive=10m;
+    # External content cache for Hayhooks
+    proxy_cache_path /var/cache/nginx/external_cache 
+                    levels=1:2 
+                    keys_zone=external_cache:20m 
+                    max_size=2g 
+                    inactive=24h;
+    
+    # SSL settings
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_dhparam /etc/nginx/certs/dhparam.pem;
+    
+    # HTTPS server
+    server {
+        listen 80;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location /health {
+            access_log off;
+            add_header 'Content-Type' 'text/plain';
+            return 200 "healthy\n";
+        }
+    }
+    
+    # Include additional configuration files
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
In theory, an nginx forward proxy should let hayhooks extract tool cache content in between calls and build up a library.

In practice, this doesn't work.  I've pointed claude at it and got not great results.