### PR TITLE
default to gemini 2.5 pro

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,8 @@ services:
       #
       #- CHAT_MODEL=google_ai/gemini-2.5-pro-preview-03-25
       - CHAT_MODEL=google_ai/gemini-2.5-pro-exp-03-25
+      # This embedding model is likewise free (for now), you can also use letta/letta-free
+      #EMBEDDING_MODEL=letta/letta-free
       - EMBEDDING_MODEL=google_ai/gemini-embedding-exp-03-07
 
   aws-documentation-mcp-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,13 +147,8 @@ services:
       # you can continue to use 'gemini-2.5-pro-exp-03-25' on the free tier.
       #   -- https://ai.google.dev/gemini-api/docs/thinking
       #
-      # Gemini 2.5 Pro is being wierd, so commenting it out for now:
-      #
-      #- CHAT_MODEL=google_ai/gemini-2.5-pro-exp-03-25
       #- CHAT_MODEL=google_ai/gemini-2.5-pro-preview-03-25
-      #
-      # Safest "live" option is gemini-2.0-flash
-      - CHAT_MODEL=google_ai/gemini-2.0-flash
+      - CHAT_MODEL=google_ai/gemini-2.5-pro-exp-03-25
       - EMBEDDING_MODEL=google_ai/gemini-embedding-exp-03-07
 
   aws-documentation-mcp-server:


### PR DESCRIPTION
Set gemini 2.5 pro as the default as it's basically free and *much* more proactive than 2.0 flash.