### PR TITLE
Match up extracted search results with URL

### DIFF
--- a/hayhooks/components/tavily_web_search.py
+++ b/hayhooks/components/tavily_web_search.py
@@ -77,7 +77,7 @@ class TavilyWebSearch:
             doc_dict = {
                 "title": result["title"],
                 "content": result["content"],
-                "link": result["url"],
+                "url": result["url"],
                 "score": result["score"],
             }
             urls.append(result["url"])

--- a/hayhooks/resources/extract_prompt.md
+++ b/hayhooks/resources/extract_prompt.md
@@ -49,7 +49,7 @@ Here is the content from the URLs:
 {% for doc in documents %}
 <document>
 <title>{{ doc.meta.title }}</title>
-<url>{{ doc.meta.link }}</url>
+<url>{{ doc.meta.url }}</url>
 <content> 
 {{ doc.content }}
 </content>

--- a/hayhooks/resources/search_prompt.md
+++ b/hayhooks/resources/search_prompt.md
@@ -8,7 +8,7 @@ Here is the context from the search engine:
 <document>
 <title>{{ doc.meta.title }}</title>
 <score>{{ doc.score }}</score>
-<url>{{ doc.meta.link }}</url>
+<url>{{ doc.meta.url }}</url>
 <content> 
 {{ doc.content }}
 </content>


### PR DESCRIPTION
The extracted search results didn't account for 404s -- use the bytestream metadata and create a map of URLs to content so that it's not using an index.

Also standardize on using URL for all documents.