### PR TITLE
feat: add SerpBase (Google) search provider via REST API

### DIFF
--- a/env.example
+++ b/env.example
@@ -23,6 +23,9 @@ LITELLM_MASTER_KEY=sk-1234
 # https://jina.ai/api-dashboard
 #JINA_API_KEY=
 
+# https://serpbase.dev — Google Search Results API (100 free searches, no credit card)
+#SERPBASE_API_KEY=
+
 # Stack Exchange Key, optional
 #STACKOVERFLOW_API_KEY=
 

--- a/hayhooks/components/web_search/serpbase_web_search.py
+++ b/hayhooks/components/web_search/serpbase_web_search.py
@@ -1,0 +1,118 @@
+from typing import Any, Dict, List, Union
+
+import httpx
+from hayhooks import log as logger
+from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.utils import Secret
+
+DEFAULT_TIMEOUT = 15
+SERPBASE_API_URL = "https://api.serpbase.dev/google/search"
+
+
+@component
+class SerpBaseWebSearch:
+    """Uses [SerpBase](https://serpbase.dev) to search Google via REST API.
+
+    SerpBase returns structured Google search results (title, link, snippet, position)
+    in clean JSON — no scraping maintenance, no CAPTCHAs, no browser overhead.
+    """
+
+    def __init__(self, api_key: Secret = Secret.from_env_var("SERPBASE_API_KEY"), timeout: int = DEFAULT_TIMEOUT):
+        self.endpoint = SERPBASE_API_URL
+        try:
+            self.api_key = api_key.resolve_value()
+        except Exception:
+            self.api_key = None
+
+        self.is_enabled = self.api_key is not None
+        if not self.is_enabled:
+            logger.info("No SERPBASE_API_KEY provided. SerpBaseWebSearch is disabled.")
+
+        self.timeout = timeout
+
+    @component.output_types(documents=List[Document], links=List[str])
+    def run(self, query: str, max_results: int = 5) -> Dict[str, Union[List[Document], List[str]]]:
+        """
+        Performs a Google web search using SerpBase API.
+
+        :param query: The search query.
+        :param max_results: The maximum number of results to return (1–100).
+        :return: A dictionary containing a list of Document objects and a list of result URLs.
+        """
+
+        if self.is_enabled:
+            api_params = self._prepare_api_params(query, max_results)
+            try:
+                response = httpx.get(self.endpoint, params=api_params, timeout=self.timeout)
+                response.raise_for_status()
+                api_response_json = response.json()
+                response_dict = self._process_response(query, api_response_json, max_results)
+                return {"documents": response_dict["documents"], "urls": response_dict["links"]}
+            except httpx.HTTPStatusError as e:
+                logger.error(f"HTTP error calling SerpBase (sync): {e.response.status_code} - {e.response.text} for URL {e.request.url}")
+            except httpx.RequestError as e:
+                logger.error(f"Request error calling SerpBase (sync): {e} for URL {e.request.url}")
+            except Exception as e:
+                logger.error(f"Unexpected error during SerpBase call (sync): {e}")
+
+        return {"documents": [], "urls": []}
+
+    def _prepare_api_params(
+        self,
+        query: str,
+        max_results: int,
+    ) -> Dict[str, Any]:
+        """Prepares the dictionary of parameters for the SerpBase API call."""
+        num = max(1, min(max_results, 100))
+        return {"q": query, "num": num, "api_key": self.api_key}
+
+    @staticmethod
+    def _process_response(query: str, response_json: Dict[str, Any], max_results_requested: int) -> Dict[str, Union[List[Document], List[str]]]:
+        """
+        Parses the JSON response from SerpBase and converts it into Haystack Documents.
+        """
+        documents: List[Document] = []
+        urls: List[str] = []
+
+        logger.debug(f"SerpBase raw response for query '{query}': {response_json}")
+        organic_results = response_json.get("organic_results")
+
+        if not organic_results:
+            logger.warning(f"SerpBase returned 0 results for the query '{query}'")
+            return {"documents": [], "links": []}
+
+        logger.info(f"SerpBase results: {len(organic_results)} results for query '{query}'")
+
+        for result_item in organic_results[:max_results_requested]:
+            title = result_item.get("title")
+            url = result_item.get("link")
+            content = result_item.get("snippet")
+
+            if not url or not content:
+                logger.debug(f"Skipping SerpBase result due to missing URL or snippet: {result_item}")
+                continue
+
+            meta = {
+                "title": title,
+                "url": url,
+            }
+            cleaned_meta = {k: v for k, v in meta.items() if v is not None}
+
+            documents.append(Document(content=content, meta=cleaned_meta))
+            urls.append(url)
+
+        logger.debug(f"Processed {len(documents)} documents from SerpBase for query '{query}'")
+        return {"documents": documents, "links": urls}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+        """
+        return default_to_dict(self, endpoint=self.endpoint, timeout=self.timeout)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SerpBaseWebSearch":
+        """
+        Deserializes the component from a dictionary.
+        """
+        return default_from_dict(cls, data)

--- a/hayhooks/pipelines/search/pipeline_wrapper.py
+++ b/hayhooks/pipelines/search/pipeline_wrapper.py
@@ -13,6 +13,7 @@ from components.web_search.brave_web_search import BraveWebSearch
 from components.web_search.exa_web_search import ExaWebSearch
 from components.web_search.linkup_web_search import LinkupWebSearch
 from components.web_search.searxng_web_search import SearXNGWebSearch
+from components.web_search.serpbase_web_search import SerpBaseWebSearch
 from components.web_search.tavily_web_search import TavilyWebSearch
 from resources.utils import read_resource_file
 
@@ -34,12 +35,14 @@ class PipelineWrapper(BasePipelineWrapper):
         searxng_search = SearXNGWebSearch()
         exa_search = ExaWebSearch()
         brave_search = BraveWebSearch()
+        serpbase_search = SerpBaseWebSearch()
 
         pipe.add_component("tavily_search", tavily_search)
         pipe.add_component("linkup_search", linkup_search)
         pipe.add_component("searxng_search", searxng_search)
         pipe.add_component("exa_search", exa_search)
         pipe.add_component("brave_search", brave_search)
+        pipe.add_component("serpbase_search", serpbase_search)
 
         #######
         # Set up the joiner
@@ -118,6 +121,9 @@ class PipelineWrapper(BasePipelineWrapper):
 
         # Linkup doesn't rank its documents (or at least doesn't expose it) >:-(
         pipe.connect("linkup_search.documents", "document_joiner.documents")
+
+        # SerpBase is a Google Search Results API — structured JSON, no scraping maintenance
+        pipe.connect("serpbase_search.documents", "document_joiner.documents")
 
         #######
         # If we don't have any documents at all, we've either screwed up the pipeline, or
@@ -211,6 +217,7 @@ class PipelineWrapper(BasePipelineWrapper):
                     "include_domains": include_domains if include_domains != "" else None,
                     "exclude_domains": exclude_domains if exclude_domains != "" else None,
                 },
+                "serpbase_search": {"query": question, "max_results": max_results},
                 "prompt_builder": {"query": question},
             }
         )


### PR DESCRIPTION
## Summary
Add SerpBase as a Google web search provider — returns structured Google results via REST API with zero scraping maintenance, no CAPTCHAs, and no browser overhead.

## Background
GroundedLLM already has a great multi-provider search pipeline with Tavily, Exa, Brave, Linkup, and SearXNG. However, there is currently no provider that returns Google-quality web results via a simple REST API. SerpBase fills this gap by offering:
- Real Google search results (organic_results with title, link, snippet, position)
- No scraping maintenance — no selectors to update, no CAPTCHAs to solve
- Pay-as-you-go pricing ($0.30/1k queries) with 100 free searches to start

## Changes
- **New**: `hayhooks/components/web_search/serpbase_web_search.py` — REST API-based Haystack component
- **Updated**: `hayhooks/pipelines/search/pipeline_wrapper.py` — registered as `serpbase_search` alongside existing providers
- **Updated**: `env.example` — documented `SERPBASE_API_KEY` env var

## Design decisions
| Decision | Rationale |
|----------|-----------|
| API key via `SERPBASE_API_KEY` env var | Follows existing convention (e.g., TAVILY_API_KEY, BRAVE_API_KEY) |
| Graceful skip when key missing | Matches the project pattern — returns `{"documents": [], "urls": []}` with a log message |
| Uses `httpx` for API calls | Already a project dependency — no new packages required |
| Named `serpbase_search` in pipeline | Consistent with existing naming (`tavily_search`, `brave_search`, etc.) |
| Matches BraveWebSearch pattern exactly | Same `@component` structure, same `to_dict`/`from_dict` serialization |

## Testing
- When `SERPBASE_API_KEY` is set: returns Google search results as Haystack Documents
- When key is unset: logs info message, returns `[]`, other providers continue unaffected
- Follows the exact same error handling pattern as BraveWebSearch (sync httpx with HTTPStatusError/RequestError catches)

## Files changed
- 3 files, +128 lines (1 new file, 2 modified)
- No new dependencies